### PR TITLE
unpin outdated deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-pillow>=5.3,<7
-scipy>=1.3,<2
+pillow
+scipy
 tensorflow>=2,<3
-keras
 tqdm>=4.41.0,<5


### PR DESCRIPTION
- Old Pillow version may not build/install
- No point pinning versions of indirect dependencies (not directly imported in `train.py`) so unpin `pillow` and `scipy`
- drop unused `keras`
- fixes/replaces/closes #8